### PR TITLE
Add a rawText method stub to the base writer

### DIFF
--- a/Lib/feaTools/writers/baseWriter.py
+++ b/Lib/feaTools/writers/baseWriter.py
@@ -53,3 +53,6 @@ class AbstractFeatureWriter(object):
 
     def subtableBreak(self):
         pass
+
+    def rawText(self, text):
+        pass


### PR DESCRIPTION
I think this is the only missing method in the base writer.