### PR TITLE
Some gposType2 functions are missing an argument

### DIFF
--- a/Lib/feaTools/writers/baseWriter.py
+++ b/Lib/feaTools/writers/baseWriter.py
@@ -36,7 +36,7 @@ class AbstractFeatureWriter(object):
     def gposType1(self, target, value):
         pass
 
-    def gposType2(self, target, value):
+    def gposType2(self, target, value, needEnum=False):
         pass
 
     def languageSystem(self, languageTag, scriptTag):

--- a/Lib/feaTools/writers/featestWriter.py
+++ b/Lib/feaTools/writers/featestWriter.py
@@ -80,7 +80,7 @@ class FeatestWriter(object):
     def gposType1(self, target, value):
         raise NotImplementedError
 
-    def gposType2(self, target, value):
+    def gposType2(self, target, value, needEnum=False):
         raise NotImplementedError
 
     def languageSystem(self, languageTag, scriptTag):

--- a/Lib/feaTools/writers/glyphRenameWriter.py
+++ b/Lib/feaTools/writers/glyphRenameWriter.py
@@ -54,6 +54,6 @@ class GlyphRenameFeatureWriter(FDKSyntaxFeatureWriter):
         target = self._rename(target)
         super(GlyphRenameFeatureWriter, self).gposType1(target, value)
 
-    def gposType2(self, target, value):
+    def gposType2(self, target, value, needEnum=False):
         target = self._rename(target)
         super(GlyphRenameFeatureWriter, self).gposType2(target, value)

--- a/Lib/feaTools/writers/printWriter.py
+++ b/Lib/feaTools/writers/printWriter.py
@@ -39,7 +39,7 @@ class PrintFeatureWriter(AbstractFeatureWriter):
     def gposType1(self, target, value):
         print ("gpos type 1", (target, value))
 
-    def gposType2(self, target, value):
+    def gposType2(self, target, value, needEnum=False):
         print ("gpos type 2", (target, value))
 
     def languageSystem(self, languageTag, scriptTag):


### PR DESCRIPTION
Some of the sample base writers (all except for the FDKSyntaxWriter) were missing an argument in the gposType2 type.

This sample code would previously throw a traceback about the number of arguments that gposType2 needed:

```
from feaTools.parser import parseFeatures
from feaTools.writers.printWriter import PrintFeatureWriter

feaText = """
# http://www.adobe.com/devnet/opentype/afdko/topic_feature_file_syntax.html#6.b.ii
@Y_LC = [y yacute ydieresis];
@SMALL_PUNC = [comma semicolon period];

feature kern {
    enum pos @Y_LC semicolon -80;    # specific pairs
    pos     f quoteright 30;         # specific pair
    pos     @Y_LC @SMALL_PUNC -100;  # class pair
} kern;
"""

writer = PrintFeatureWriter()
parseFeatures(writer, feaText)
```