### PR TITLE
Update all the regex strings in parser.py to be raw strings

### DIFF
--- a/Lib/feaTools/parser.py
+++ b/Lib/feaTools/parser.py
@@ -1,4 +1,6 @@
-from __future__ import print_function, division, absolute_import, unicode_literals
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
 import re
 
 
@@ -12,261 +14,261 @@ class FeaToolsParserSyntaxError(Exception):
 
 
 # used for removing all comments
-commentRE = re.compile("#.*")
+commentRE = re.compile(r"#.*")
 
 # used for finding all strings
 stringRE = re.compile(
-    "\""         # "
-    "([^\"]*)"   # anything but "
-    "\""         # "
+    r"\""         # "
+    r"([^\"]*)"   # anything but "
+    r"\""         # "
 )
 
 # used for removing all comments
-terminatorRE = re.compile(";")
+terminatorRE = re.compile(r";")
 
 # used for finding all feature names.
 feature_findAll_RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "feature\s+"           # feature
-        "([\w\d]{4})"          # name
-        "\s*{"                 # {
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"feature\s+"           # feature
+        r"([\w\d]{4})"          # name
+        r"\s*{"                 # {
         )
 
 # used for finding the content of features.
 # this regular expression will be compiled
 # for each feature name found.
 featureContentRE = [
-        "([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
-        "feature\s+",          # feature
+        r"([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
+        r"feature\s+",          # feature
         # feature name         # name
-        "\s*\{",               # {
-        "([\S\s]*?)",          # content
-        "}\s*",                # }
+        r"\s*\{",               # {
+        r"([\S\s]*?)",          # content
+        r"}\s*",                # }
         # feature name         # name
-        "\s*;"                 # ;
+        r"\s*;"                 # ;
         ]
 
 # used for finding all lookup names.
 lookup_findAll_RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "lookup\s+"            # lookup
-        "([\w\d_.]+)"          # name
-        "\s*{"                 # {
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"lookup\s+"            # lookup
+        r"([\w\d_.]+)"          # name
+        r"\s*{"                 # {
         )
 
 # used for finding the content of lookups.
 # this regular expression will be compiled
 # for each lookup name found.
 lookupContentRE = [
-        "([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
-        "lookup\s+",           # lookup
+        r"([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
+        r"lookup\s+",           # lookup
         # lookup name          # name
-        "\s*\{",               # {
-        "([\S\s]*?)",          # content
-        "}\s*",                # }
+        r"\s*\{",               # {
+        r"([\S\s]*?)",          # content
+        r"}\s*",                # }
         # lookup name          # name
-        "\s*;"                 # ;
+        r"\s*;"                 # ;
         ]
 
 # used for finding all table names.
 table_findAll_RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "table\s+"             # table
-        "([\w\d/]+)"        # name
-        "\s*{"                 # {
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"table\s+"             # table
+        r"([\w\d/]+)"        # name
+        r"\s*{"                 # {
         )
 
 # used for finding the content of tables.
 # this regular expression will be compiled
 # for each table name found.
 tableContentRE = [
-        "([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
-        "table\s+",            # feature
+        r"([\s;\{\}]|^)",       # whitepace, ; {, } or start of line
+        r"table\s+",            # feature
         # table name           # name
-        "\s*\{",               # {
-        "([\S\s]*?)",          # content
-        "}\s*",                # }
+        r"\s*\{",               # {
+        r"([\S\s]*?)",          # content
+        r"}\s*",                # }
         # table name           # name
-        "\s*;"                 # ;
+        r"\s*;"                 # ;
         ]
 
 # used for getting tag value pairs from tables.
 tableTagValueRE = re.compile(
-    "([\w\d_.]+)"       # tag
-    "\s+"               #
-    "([^;]+)"           # anything but ;
-    ";"                 # ;
+    r"([\w\d_.]+)"       # tag
+    r"\s+"               #
+    r"([^;]+)"           # anything but ;
+    r";"                 # ;
 )
 
 # used for finding all class definitions.
 classDefinitionRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "@"                    # @
-        "([\w\d_.]+)"          # name
-        "\s*=\s*"              #  = 
-        "\["                   # [
-        "([\w\d\s\-_.@]+)"     # content
-        "\]"                   # ]
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"@"                    # @
+        r"([\w\d_.]+)"          # name
+        r"\s*=\s*"              #  =
+        r"\["                   # [
+        r"([\w\d\s\-_.@]+)"     # content
+        r"\]"                   # ]
+        r"\s*;"                 # ;
         , re.M
         )
 
 # used for getting the contents of a class definition
 classContentRE = re.compile(
-        "([\w\d\-_.@]+)"
+        r"([\w\d\-_.@]+)"
         )
 
 # used for finding inline classes within a sequence
 sequenceInlineClassRE = re.compile(
-        "\["                   # [
-        "([\w\d\s_.@]+)"       # content
-        "\]"                   # ]
+        r"\["                   # [
+        r"([\w\d\s_.@]+)"       # content
+        r"\]"                   # ]
         )
 
 # used for finding all substitution type 1
 subType1And2And4RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "substitute|sub\s+"    # sub
-        "([\w\d\s_.@\[\]]+)"   # target
-        "\s+by\s+"             #  by
-        "([\w\d\s_.@\[\]]+)"   # replacement
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"substitute|sub\s+"    # sub
+        r"([\w\d\s_.@\[\]]+)"   # target
+        r"\s+by\s+"             #  by
+        r"([\w\d\s_.@\[\]]+)"   # replacement
+        r"\s*;"                 # ;
         )
 
 # used for finding all substitution type 3
 subType3RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "substitute|sub\s+"    # sub
-        "([\w\d\s_.@\[\]]+)"   # target
-        "\s+from\s+"           #  from
-        "([\w\d\s_.@\[\]]+)"   # replacement
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"substitute|sub\s+"    # sub
+        r"([\w\d\s_.@\[\]]+)"   # target
+        r"\s+from\s+"           #  from
+        r"([\w\d\s_.@\[\]]+)"   # replacement
+        r"\s*;"                 # ;
         )
 
 # used for finding all ignore substitution type 6
 ignoreSubType6RE = re.compile(
-        "([\s;\{\}]|^)"                          # whitepace, ; {, } or start of line
-        "ignore\s+substitute|ignore\s+sub\s+"    # ignore sub
-        "([\w\d\s_.@\[\]']+)"                    # preceding context, target, trailing context
-        "\s*;"                                   # ;
+        r"([\s;\{\}]|^)"                          # whitepace, ; {, } or start of line
+        r"ignore\s+substitute|ignore\s+sub\s+"    # ignore sub
+        r"([\w\d\s_.@\[\]']+)"                    # preceding context, target, trailing context
+        r"\s*;"                                   # ;
         )
 
 # used for finding all substitution type 6
 # XXX see failing unit test
 subType6RE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "substitute|sub\s+"    # sub
-        "([\w\d\s_.@\[\]']+)"  # preceding context, target, trailing context
-        "\s+by\s+"             #  by
-        "([\w\d\s_.@\[\]]+)"   # replacement
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"substitute|sub\s+"    # sub
+        r"([\w\d\s_.@\[\]']+)"  # preceding context, target, trailing context
+        r"\s+by\s+"             #  by
+        r"([\w\d\s_.@\[\]]+)"   # replacement
+        r"\s*;"                 # ;
         )
 
 subType6TargetRE = re.compile(
-        "(\["                  # [
-        "[\w\d\s_.@]+"         # content
-        "\]"                   # ]'
-        "|"                    # <or>
-        "[\w\d_.@]+)'"         # content
+        r"(\["                  # [
+        r"[\w\d\s_.@]+"         # content
+        r"\]"                   # ]'
+        r"|"                    # <or>
+        r"[\w\d_.@]+)'"         # content
         )
 
 subType6TargetExtractRE = re.compile(
-        "([\w\d_.@]*)"       # glyph or class names
+        r"([\w\d_.@]*)"       # glyph or class names
         )
 
 # used for finding positioning type 1
 posType1RE = re.compile(
-    "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-    "position|pos\s+"      # pos
-    "([\w\d\s_.@\[\]]+)"   # target
-    "\s+<"                 # <
-    "([-\d\s]+)"           # value
-    "\s*>\s*;"             # >;
+    r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+    r"position|pos\s+"      # pos
+    r"([\w\d\s_.@\[\]]+)"   # target
+    r"\s+<"                 # <
+    r"([-\d\s]+)"           # value
+    r"\s*>\s*;"             # >;
     )
 
 # used for finding positioning type 2
 posType2RE = re.compile(
-    "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-    "(enum\s+|\s*)"        # enum
-    "(position|pos\s+)"    # pos
-    "([-\w\d\s_.@\[\]]+)"  # left, right, value
-    "\s*;"                 # ;
+    r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+    r"(enum\s+|\s*)"        # enum
+    r"(position|pos\s+)"    # pos
+    r"([-\w\d\s_.@\[\]]+)"  # left, right, value
+    r"\s*;"                 # ;
     )
 
 # used for finding all languagesystem
 languagesystemRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "languagesystem\s+"    # languagesystem
-        "([\w\d]+)"            # script tag
-        "\s+"                  #
-        "([\w\d]+)"            # language tag
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"languagesystem\s+"    # languagesystem
+        r"([\w\d]+)"            # script tag
+        r"\s+"                  #
+        r"([\w\d]+)"            # language tag
+        r"\s*;"                 # ;
         )
 
 # use for finding all script
 scriptRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "script\s+"            # script
-        "([\w\d]+)"            # script tag
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"script\s+"            # script
+        r"([\w\d]+)"            # script tag
+        r"\s*;"                 # ;
         )
 
 # used for finding all language
 languageRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "language\s+"          # language
-        "([\w\d]+)"            # language tag
-        "\s*"                  # 
-        "([\w\d]*)"            # include_dflt or exclude_dflt or nothing
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"language\s+"          # language
+        r"([\w\d]+)"            # language tag
+        r"\s*"                  #
+        r"([\w\d]*)"            # include_dflt or exclude_dflt or nothing
+        r"\s*;"                 # ;
         )
 
 # use for finding all includes
 includeRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "include\s*"           # include
-        "\(\s*"                # (
-        "([^\)]+)"             # anything but )
-        "\s*\)"                # )
-        "\s*;{0,1}"            # ; which will occur zero or one times (ugh!)
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"include\s*"           # include
+        r"\(\s*"                # (
+        r"([^\)]+)"             # anything but )
+        r"\s*\)"                # )
+        r"\s*;{0,1}"            # ; which will occur zero or one times (ugh!)
         )
 
 # used for finding subtable breaks
 subtableRE = re.compile(
-    "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-    "subtable\s*"          # subtable
-    "\s*;"                 # ;
+    r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+    r"subtable\s*"          # subtable
+    r"\s*;"                 # ;
 )
 
 # used for finding feature references
 featureReferenceRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "feature\s+"           # feature
-        "([\w\d]{4})"          # name
-        "\s*;"                 # {
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"feature\s+"           # feature
+        r"([\w\d]{4})"          # name
+        r"\s*;"                 # {
         )
 
 # used for finding lookup references
 lookupReferenceRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "lookup\s+"            # lookup
-        "([\w\d]+)"            # name
-        "\s*;"                 # {
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"lookup\s+"            # lookup
+        r"([\w\d]+)"            # name
+        r"\s*;"                 # {
         )
 
 # use for finding all lookup flags
 lookupflagRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "lookupflag\s+"        # lookupflag
-        "([\w\d,\s]+)"         # values
-        "\s*;"                 # ;
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"lookupflag\s+"        # lookupflag
+        r"([\w\d,\s]+)"         # values
+        r"\s*;"                 # ;
         )
 
 # used for finding all stylistic set featureNames.
 featureNamesRE = re.compile(
-        "([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
-        "featureNames"         # featureNames
-        "[\S\s]*?}\s*;"        # everything up until }; with whitespace
+        r"([\s;\{\}]|^)"        # whitepace, ; {, } or start of line
+        r"featureNames"         # featureNames
+        r"[\S\s]*?}\s*;"        # everything up until }; with whitespace
         )
 
 
@@ -653,11 +655,11 @@ def parseFeatures(writer, text):
     # (an alternative approach would be to escape the strings.
     # the problem is that a string could contain parsable text
     # that would fool the parsing algorithm.)
-    text = stringRE.sub("", text)
+    text = stringRE.sub(r"", text)
     # strip the comments
-    text = commentRE.sub("", text)
+    text = commentRE.sub(r"", text)
     # make sure there is a space after all ;
     # since it makes the text more digestable
     # for the regular expressions
-    text = terminatorRE.sub("; ", text)
+    text = terminatorRE.sub(r"; ", text)
     _parseUnknown(writer, text)


### PR DESCRIPTION
I was getting warnings like the following when using feaTools in Python3:
```
/Users/ford/git/feaTools/Lib/feaTools/parser.py:29: DeprecationWarning: invalid escape sequence \s
/Users/ford/git/feaTools/Lib/feaTools/parser.py:30: DeprecationWarning: invalid escape sequence \s
/Users/ford/git/feaTools/Lib/feaTools/parser.py:31: DeprecationWarning: invalid escape sequence \w
/Users/ford/git/feaTools/Lib/feaTools/parser.py:32: DeprecationWarning: invalid escape sequence \s

... etc
```

A solution is to convert all those strings in `parser.py` to be raw strings. I converted all the regex strings at the top of the file to be raw strings for consistency. 
